### PR TITLE
refactor: централизовать пути роутера (routerConfig)

### DIFF
--- a/src/app/routers/AppRouter.tsx
+++ b/src/app/routers/AppRouter.tsx
@@ -9,23 +9,24 @@ import { CollectionsPage } from '@pages/collections'
 import { Navigation } from '@widgets/navigation'
 import { CollectionSidebar } from '@widgets/collection-sidebar'
 import { SongNewPage } from '@pages/song-new'
+import { routerConfig } from '@shared/config/routerConfig'
 
 const router = createBrowserRouter([
   {
     element: <AuthLayout />,
     children: [
       {
-        path: '/login',
+        path: routerConfig.login,
         element: <LoginPage />,
         errorElement: <NotFoundPage />,
       },
       {
-        path: '/registration',
+        path: routerConfig.registration,
         element: <RegistrationPage />,
         errorElement: <NotFoundPage />,
       },
       // {
-      //   path: "/reset-password",
+      //   path: routerConfig.resetPassword,
       //   element: <ResetPasswordPage/>,
       //   errorElement: <NotFoundPage/>,
       // },
@@ -35,36 +36,36 @@ const router = createBrowserRouter([
     element: <MainLayout sidebar={<Navigation />} />,
     children: [
       {
-        path: '/',
+        path: routerConfig.root,
         element: <CollectionsPage />,
         errorElement: <NotFoundPage />,
       },
       {
-        path: '/collections',
+        path: routerConfig.collections,
         element: <CollectionsPage />,
         errorElement: <NotFoundPage />,
       },
       // {
-      //   path: "/profile",
+      //   path: routerConfig.profile,
       //   errorElement: <NotFoundPage/>,
       // },
       // {
-      //   path: "/settings",
+      //   path: routerConfig.settings,
       //   errorElement: <NotFoundPage/>,
       // },
     ],
   },
   {
-    path: '/collections/:collectionId/songs',
+    path: routerConfig.collectionSongs,
     element: <MainLayout size='big' sidebar={<CollectionSidebar />} />,
     children: [
       {
-        path: '/collections/:collectionId/songs/:songId',
+        path: routerConfig.collectionSong,
         element: <SongPage />,
         errorElement: <NotFoundPage />,
       },
       {
-        path: '/collections/:collectionId/songs/new',
+        path: routerConfig.collectionSongNew,
         element: <SongNewPage />,
         errorElement: <NotFoundPage />,
       },

--- a/src/entities/collection/ui/collection-card/CollectionCard.tsx
+++ b/src/entities/collection/ui/collection-card/CollectionCard.tsx
@@ -2,6 +2,7 @@ import { FC, ReactNode } from 'react'
 import './CollectionCard.scss'
 import { ICollection } from '../../model/collectionType'
 import { useNavigate } from 'react-router-dom'
+import { routerConfig } from '@shared/config/routerConfig'
 
 interface IProps {
   collection: ICollection
@@ -18,7 +19,12 @@ export const CollectionCard: FC<IProps> = ({
 
   const handleRedirect = () => {
     if (collection) {
-      navigate(`/collections/${collection.id}/songs`)
+      navigate(
+        routerConfig.collectionSongs.replace(
+          ':collectionId',
+          collection.id.toString()
+        )
+      )
     }
   }
 

--- a/src/entities/collection/ui/collection-select/CollectionSelect.tsx
+++ b/src/entities/collection/ui/collection-select/CollectionSelect.tsx
@@ -4,6 +4,7 @@ import { collectionApi } from '../../api/collectionApi'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Select } from '@shared/ui/select'
 import { Transition } from '@shared/lib/transition'
+import { routerConfig } from '@shared/config/routerConfig'
 
 export const CollectionSelect: FC = () => {
   const navigate = useNavigate()
@@ -22,7 +23,7 @@ export const CollectionSelect: FC = () => {
 
   const handlerChange = (id: string) => {
     setAciveCollectionId(id)
-    navigate(`/collections/${id}/songs`)
+    navigate(routerConfig.collectionSongs.replace(':collectionId', id))
   }
 
   return (

--- a/src/entities/song/ui/song-card/SongCard.tsx
+++ b/src/entities/song/ui/song-card/SongCard.tsx
@@ -2,6 +2,7 @@ import { FC, ReactNode } from 'react'
 import './SongCard.scss'
 import { useNavigate } from 'react-router-dom'
 import type { ISong } from '@entities/song'
+import { routerConfig } from '@shared/config/routerConfig'
 
 interface ISongCard {
   song: ISong
@@ -12,7 +13,9 @@ export const SongCard: FC<ISongCard> = ({ song, likeSong }) => {
   const navigate = useNavigate()
 
   const handleRedirect = () => {
-    const link = `/collections/${song.collectionId}/songs/${song.id}`
+    const link = routerConfig.collectionSong
+      .replace(':collectionId', song.collectionId.toString())
+      .replace(':songId', song.id.toString())
     navigate(link)
   }
 

--- a/src/features/add-song/ui/AddSongForm.tsx
+++ b/src/features/add-song/ui/AddSongForm.tsx
@@ -1,5 +1,6 @@
 import { ISongEditable, songApi, SongForm } from '@entities/song'
 import { useNavigate, useParams } from 'react-router-dom'
+import { routerConfig } from '@shared/config/routerConfig'
 
 export const AddSongForm = () => {
   const navigate = useNavigate()
@@ -8,7 +9,16 @@ export const AddSongForm = () => {
   const [addSong, { isLoading }] = songApi.useAddSongMutation()
 
   const navigateToSongs = (songId: string = '') => {
-    navigate(`/collections/${collectionId}/songs/${songId}`)
+    if (!collectionId) return
+    if (!songId) {
+      navigate(routerConfig.collectionSongs.replace(':collectionId', collectionId))
+      return
+    }
+    navigate(
+      routerConfig.collectionSong
+        .replace(':collectionId', collectionId)
+        .replace(':songId', songId)
+    )
   }
 
   const handleSubmit = async (form: ISongEditable) => {

--- a/src/features/configurate-songs/ui/delete-song/DeleteSong.tsx
+++ b/src/features/configurate-songs/ui/delete-song/DeleteSong.tsx
@@ -6,6 +6,7 @@ import { Notification } from '@shared/ui/notification'
 import { ConfigurateItem } from '@features/configurate-songs'
 import { useNavigate } from 'react-router-dom'
 import { ISong, songApi } from '@entities/song'
+import { routerConfig } from '@shared/config/routerConfig'
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
   song: ISong
@@ -27,9 +28,9 @@ export const DeleteSong: FC<IProps> = ({ song, collectionId }) => {
     // TODO Настроить вывод попапа после удаления
 
     if (collectionId) {
-      navigate(`/collections/${collectionId}/songs/`)
+      navigate(routerConfig.collectionSongs.replace(':collectionId', collectionId))
     } else {
-      navigate(`/collections/`)
+      navigate(routerConfig.collections)
     }
   }
 

--- a/src/features/login/ui/LoginForm.tsx
+++ b/src/features/login/ui/LoginForm.tsx
@@ -5,6 +5,7 @@ import './LoginForm.scss'
 import { authApi } from '@entities/auth'
 import { useNavigate } from 'react-router-dom'
 import { GoogleLoginButton } from './GoogleLoginButton'
+import { routerConfig } from '@shared/config/routerConfig'
 
 export const LoginForm = () => {
   const navigate = useNavigate()
@@ -23,7 +24,7 @@ export const LoginForm = () => {
     if (response.error) {
       setError('Неверный email или пароль')
     } else {
-      navigate('/collections')
+      navigate(routerConfig.collections)
     }
   }
 

--- a/src/features/register/ui/RegistrationForm.tsx
+++ b/src/features/register/ui/RegistrationForm.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom'
 import { Popup } from '@shared/ui/popup'
 import { PRIVACY_POLICY_TEXT } from '@shared/config/privacy-policy'
 import { authApi } from '@entities/auth'
+import { routerConfig } from '@shared/config/routerConfig'
 
 export const RegistrationForm = () => {
   const navigate = useNavigate()
@@ -24,7 +25,7 @@ export const RegistrationForm = () => {
     await register(form)
 
     if (data) {
-      navigate('/collections')
+      navigate(routerConfig.collections)
     } else {
       setError(String(data))
     }

--- a/src/pages/login/ui/LoginPage.tsx
+++ b/src/pages/login/ui/LoginPage.tsx
@@ -1,13 +1,14 @@
 import { UILink } from '@shared/ui/link'
 import { LoginForm } from '@features/login'
+import { routerConfig } from '@shared/config/routerConfig'
 
 export const LoginPage = () => {
   return (
     <>
       <h1>Вход в аккаунт</h1>
       <LoginForm />
-      {/* <UILink to='/reset-password'>Востановить пароль</UILink> */}
-      <UILink to='/registration'>Зарегестироваться</UILink>
+      {/* <UILink to={routerConfig.resetPassword}>Востановить пароль</UILink> */}
+      <UILink to={routerConfig.registration}>Зарегестироваться</UILink>
     </>
   )
 }

--- a/src/pages/registration/ui/RegistrationPage.tsx
+++ b/src/pages/registration/ui/RegistrationPage.tsx
@@ -1,12 +1,13 @@
 import { UILink } from '@shared/ui/link'
 import { RegistrationForm } from '@features/register'
+import { routerConfig } from '@shared/config/routerConfig'
 
 export const RegistrationPage = () => {
   return (
     <>
       <h1>Зарегистироваться</h1>
       <RegistrationForm />
-      <UILink to='/login'>Войти</UILink>
+      <UILink to={routerConfig.login}>Войти</UILink>
     </>
   )
 }

--- a/src/pages/reset-password/ui/ResetPasswordPage.tsx
+++ b/src/pages/reset-password/ui/ResetPasswordPage.tsx
@@ -1,12 +1,13 @@
 import { UILink } from '@shared/ui/link'
 import { ResetPasswordForm } from '@features/reset-password'
+import { routerConfig } from '@shared/config/routerConfig'
 
 export const ResetPasswordPage = () => {
   return (
     <>
       <h1>Восстановить пароль</h1>
       <ResetPasswordForm />
-      <UILink to='/login'>Войти</UILink>
+      <UILink to={routerConfig.login}>Войти</UILink>
     </>
   )
 }

--- a/src/shared/api/baseQuery.ts
+++ b/src/shared/api/baseQuery.ts
@@ -9,6 +9,7 @@ import type {
 import { authApi } from '@entities/auth'
 import { API_URL } from '@shared/config'
 import { convertKeys } from '@shared/utils/convert-case'
+import { routerConfig } from '@shared/config/routerConfig'
 
 export const baseQueryFn = fetchBaseQuery({
   baseUrl: API_URL,
@@ -40,7 +41,7 @@ export const baseQuery: BaseQueryFn<
     } else {
       console.warn('Failed to refresh token, logging out')
       api.dispatch(authApi.endpoints.logout.initiate())
-      window.location.href = '/login'
+      window.location.href = routerConfig.login
     }
   }
 

--- a/src/shared/config/routerConfig.ts
+++ b/src/shared/config/routerConfig.ts
@@ -1,0 +1,12 @@
+export const routerConfig = {
+  root: '/',
+  login: '/login',
+  registration: '/registration',
+  resetPassword: '/reset-password',
+  profile: '/profile',
+  settings: '/settings',
+  collections: '/collections',
+  collectionSongs: '/collections/:collectionId/songs',
+  collectionSong: '/collections/:collectionId/songs/:songId',
+  collectionSongNew: '/collections/:collectionId/songs/new',
+} as const

--- a/src/shared/layouts/auth-layout/AuthLayout.tsx
+++ b/src/shared/layouts/auth-layout/AuthLayout.tsx
@@ -1,12 +1,13 @@
 import { Outlet } from 'react-router-dom'
 import './AuthLayout.scss'
 import { FC } from 'react'
+import { routerConfig } from '@shared/config/routerConfig'
 
 export const AuthLayout: FC = () => {
   return (
     <div className='auth-layout'>
       <div className='auth-layout__container'>
-        <a href='/' className='auth-layout__logo'>
+        <a href={routerConfig.root} className='auth-layout__logo'>
           Songix
         </a>
         <Outlet />

--- a/src/widgets/collection-sidebar/ui/CollectionSidebar.tsx
+++ b/src/widgets/collection-sidebar/ui/CollectionSidebar.tsx
@@ -4,13 +4,14 @@ import { FilterSongs } from '@features/filter-songs'
 import './CollectionSidebar.scss'
 import { Button } from '@shared/ui/button'
 import { CollectionSelect } from '@entities/collection'
+import { routerConfig } from '@shared/config/routerConfig'
 
 export const CollectionSidebar = () => {
   const { collectionId = '' } = useParams()
   const navigate = useNavigate()
 
   const handleRedirect = () => {
-    navigate('/')
+    navigate(routerConfig.root)
   }
 
   return (
@@ -26,7 +27,10 @@ export const CollectionSidebar = () => {
 
       <Button
         color='light'
-        to={`/collections/${collectionId}/songs/new`}
+        to={routerConfig.collectionSongNew.replace(
+          ':collectionId',
+          collectionId
+        )}
         icon=''
       >
         Добавить

--- a/src/widgets/navigation/ui/navigation/LogoutButton.tsx
+++ b/src/widgets/navigation/ui/navigation/LogoutButton.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react'
 import { Button } from '@shared/ui/button'
 import { authApi } from '@entities/auth'
 import { useNavigate } from 'react-router-dom'
+import { routerConfig } from '@shared/config/routerConfig'
 
 export const LogoutButton: FC = () => {
   const [logout] = authApi.useLogoutMutation()
@@ -9,7 +10,7 @@ export const LogoutButton: FC = () => {
 
   const handleLogout = async () => {
     await logout()
-    navigate('/login')
+    navigate(routerConfig.login)
   }
 
   return <Button color='grey' icon='rr-sign-out-alt' onClick={handleLogout} />

--- a/src/widgets/navigation/ui/navigation/Navigation.tsx
+++ b/src/widgets/navigation/ui/navigation/Navigation.tsx
@@ -2,15 +2,27 @@ import './Navigation.scss'
 import { UILink } from '@shared/ui/link'
 import { MouseEvent } from 'react'
 import { LogoutButton } from './LogoutButton'
+import { routerConfig } from '@shared/config/routerConfig'
 
 export const Navigation = () => {
   const links = [
     // { id: 0, link: '/', icon: 'rr-apps', title: 'Главная' },
-    { id: 1, link: '/collections', icon: 'rr-music-alt', title: 'Сборники' },
-    { id: 2, link: '/profile', icon: 'rr-user', title: 'Профиль', soon: true },
+    {
+      id: 1,
+      link: routerConfig.collections,
+      icon: 'rr-music-alt',
+      title: 'Сборники',
+    },
+    {
+      id: 2,
+      link: routerConfig.profile,
+      icon: 'rr-user',
+      title: 'Профиль',
+      soon: true,
+    },
     {
       id: 3,
-      link: '/settings',
+      link: routerConfig.settings,
       icon: 'rr-settings',
       title: 'Настройки',
       soon: true,


### PR DESCRIPTION
### Motivation

- Убрать разбросанные строковые пути и иметь единую точку правки для всех маршрутов в приложении.
- Упростить составление ссылок с параметрами и уменьшить риск рассинхронизации путей.

### Description

- Добавлен `src/shared/config/routerConfig.ts` с константным объектом `routerConfig` для всех путей.
- Обновлён роутер в `src/app/routers/AppRouter.tsx` и использованы значения из `routerConfig` вместо строковых путей.
- Заменены все основные места навигации и ссылок на использование `routerConfig` (напр., `navigate(routerConfig.collectionSongs.replace(':collectionId', id))`), а также обновлён редирект при истечении токена в `src/shared/api/baseQuery.ts`.
- Обновлены компоненты навигации и кнопки (`Navigation`, `LogoutButton`, `CollectionSelect`, `CollectionCard`, `SongCard`, `AddSongForm`, `DeleteSong` и др.) для использования новых констант вместо литеральных путей.

### Testing

- Автоматические тесты не запускались.
- Локальная сборка/компиляция не запускалась в рамках этого изменения (требуется запуск CI/локальной проверки по желанию).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953edb6425c8331934fdb227a6228ea)